### PR TITLE
added error handling for DoC API fail

### DIFF
--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -1,4 +1,4 @@
-const Title = ({ startGame }) => {
+const Title = ({ startGame, deckLoaded }) => {
   return (
     <header id="header" className="header">
       <h1 className="header__title">Welcome to Pokemon Blackjack!</h1>
@@ -16,11 +16,12 @@ const Title = ({ startGame }) => {
       </div>
 
       <button 
-        className="btn btn__play" 
+        className={`btn btn__play ${!deckLoaded ? 'disabled' : '' } `}
         type="button"
         onClick={startGame}
+        disabled={!deckLoaded}
       >
-        Play Now
+        {!deckLoaded ? 'Loading...' : 'Play Now ' }
       </button>
     </header>
   );

--- a/src/utils/fetchRetry.js
+++ b/src/utils/fetchRetry.js
@@ -1,0 +1,24 @@
+//https://blog.bearer.sh/add-retry-to-api-calls-javascript-node/
+
+function fetchRetry(url, options = {}, retries = 5, backoff = 300) {
+    /* 1 */
+    
+    return fetch(url, options)
+        .then(res => {
+            if (res.ok) return res.json()
+
+            if (retries > 0) {
+                setTimeout(() => {
+                    /* 2 */
+                    return fetchRetry(url, options, retries - 1, backoff * 2) /* 3 */
+                }, backoff) /* 2 */
+            } else {
+                throw new Error(res)
+            }
+        })
+        .catch((error) => {
+            console.log(error, "inside the fetchRetry")
+        })
+}
+
+export default fetchRetry;


### PR DESCRIPTION
If the DoC (Deck of Cards) API call fails, our app will retry calling it 5 times.

This functionality is being handled by calling the fetchRetry function which lives in 'utils/fetchRetry.js' .

While our app is retrieving the DoC data, the 'Play now' button will show 'Loading...' . 

A ternary was added to check if we have received our decks from the API. If the API call fails, a class of 'disabled' is added.

In a future card, we will style this button with the newly created 'disabled' class.